### PR TITLE
Fix build.bat, improve README.md

### DIFF
--- a/msi-example/README.md
+++ b/msi-example/README.md
@@ -26,12 +26,12 @@ do not change that UUID.
 for example). Replace `{{{VERSION}}}` in build.bat with that version.
 
 4. Download the amd64 MSM from [Wintun.net](https://www.wintun.net/) and compute its SHA2-256
-sum in all lowercase hex digits using `CertUtil -hashfile "path/to/file" SHA256`, and replace
-`{{{64BIT HASH}}}` in build.bat with that value.
+sum in all lowercase hex digits (without any spaces) using `CertUtil -hashfile "path/to/file"
+SHA256`, and replace `{{{64BIT HASH}}}` in build.bat with that value.
 
 5. Download the x86 MSM from [Wintun.net](https://www.wintun.net/) and compute its SHA2-256
-sum in all lowercase hex digits using `CertUtil -hashfile "path/to/file" SHA256`, and replace
-`{{{32BIT HASH}}}` in build.bat with that value.
+sum in all lowercase hex digits (without any spaces) using `CertUtil -hashfile "path/to/file"
+SHA256`, and replace `{{{32BIT HASH}}}` in build.bat with that value.
 
 6. Run build.bat.
 

--- a/msi-example/build.bat
+++ b/msi-example/build.bat
@@ -20,7 +20,7 @@ if exist .deps\prepared goto :build
 	call :download wix-binaries.zip http://wixtoolset.org/downloads/v3.14.0.2812/wix314-binaries.zip 923892298f37514622c58cbbd9c2cadf2822d9bb53df8ee83aaeb05280777611 || goto :error
 	echo [+] Extracting wix-binaries.zip
 	mkdir wix\bin || goto :error
-	tar -xf wix-binaries.zip -C wix\bin || goto :error
+	unzip wix-binaries.zip -d wix\bin || goto :error
 	echo [+] Cleaning up wix-binaries.zip
 	del wix-binaries.zip || goto :error
 	copy /y NUL prepared > NUL || goto :error


### PR DESCRIPTION
* Use unzip instead of tar. zip files can't be extracted with tar.
* Be specific that the spaces are not part of the value.