### PR TITLE
Fix bad driver references on Update

### DIFF
--- a/installer/installation.c
+++ b/installer/installation.c
@@ -345,9 +345,9 @@ static BOOL RemoveWintun(VOID)
         {
             PathStripPath(DriverDetail->InfFileName);
             Logger(LOG_INFO, TEXT("Removing existing driver"));
-            if (!SetupUninstallOEMInf(DriverDetail->InfFileName, SUOI_FORCEDELETE, NULL))
+            if (!SetupUninstallOEMInf(DriverDetail->InfFileName, 0, NULL))
             {
-                PrintError(LOG_ERR, TEXT("Unable to remove existing driver"));
+                PrintError(LOG_WARN, TEXT("Unable to remove existing driver"));
                 Ret = FALSE;
             }
         }
@@ -601,8 +601,7 @@ BOOL InstallOrUpdate(VOID)
     }
     if (!RemoveWintun())
     {
-        PrintError(LOG_ERR, TEXT("Failed to uninstall old drivers"));
-        goto cleanupAdapters;
+        PrintError(LOG_WARN, TEXT("Failed to uninstall old drivers, probably some are in use by adapters. Continuing."));
     }
     if (!InstallWintun(!!ExistingAdapters))
     {


### PR DESCRIPTION
Enforcing driver removal during update breaks ownership references if persistent adapters exist.
See [resolved issue](https://github.com/OpenVPN/tap-windows6/issues/129) for similar condition in OpenVPN context. Tests [confirm](https://github.com/OpenVPN/tap-windows6/issues/129#issuecomment-702938786) the Wintun MSM will also be affected in this matter.

Mirror [tested fix](https://github.com/OpenVPN/tap-windows6/pull/135) for this issue implemented by @lstipakov.